### PR TITLE
Feature/jskim take ghep vector

### DIFF
--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -81,11 +81,11 @@ public:
 
   /// Calculates configured response for a given GHep record
   virtual systtools::event_unit_response_t
-  GetEventResponses(genie::EventRecord const &) = 0;
+  GetEventResponse(genie::EventRecord const &) = 0;
 
   /// Calculates configured response for a given vector of GHep record
   virtual std::unique_ptr<systtools::EventResponse>
-  GetEventResponse(std::vector<std::unique_ptr<genie::EventRecord>> const &gheps){
+  GetEventResponses(std::vector<std::unique_ptr<genie::EventRecord>> const &gheps){
 
     std::unique_ptr<systtools::EventResponse> er =
         std::make_unique<systtools::EventResponse>();

--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -81,7 +81,7 @@ public:
 
   /// Calculates configured response for a given GHep record
   virtual systtools::event_unit_response_t
-  GetEventResponse(genie::EventRecord const &) = 0;
+  GetEventResponses(genie::EventRecord const &) = 0;
 
   /// Calculates configured response for a given vector of GHep record
   virtual std::unique_ptr<systtools::EventResponse>

--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -83,6 +83,20 @@ public:
   virtual systtools::event_unit_response_t
   GetEventResponse(genie::EventRecord const &) = 0;
 
+  /// Calculates configured response for a given vector of GHep record
+  virtual std::unique_ptr<systtools::EventResponse>
+  GetEventResponse(std::vector<std::unique_ptr<genie::EventRecord>> const &gheps){
+
+    std::unique_ptr<systtools::EventResponse> er =
+        std::make_unique<systtools::EventResponse>();
+
+    for (size_t eu_it = 0; eu_it < gheps.size(); ++eu_it) {
+      er->push_back(GetEventResponse(*gheps[eu_it]));
+    }
+    return er;
+
+  };
+
   systtools::event_unit_response_w_cv_t
   GetEventVariationAndCVResponse(genie::EventRecord const &GenieGHep) {
     systtools::event_unit_response_w_cv_t responseandCV;

--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -84,7 +84,7 @@ public:
   GetEventResponse(genie::EventRecord const &) = 0;
 
   /// Calculates configured response for a given vector of GHep record
-  virtual std::unique_ptr<systtools::EventResponse>
+  std::unique_ptr<systtools::EventResponse>
   GetEventResponses(std::vector<std::unique_ptr<genie::EventRecord>> const &gheps){
 
     std::unique_ptr<systtools::EventResponse> er =


### PR DESCRIPTION
`GetEventResponses` added which takes a vector of genie::EventRecord, and loops over it, and calls `GetEventResponse` for each of the record. It is a replacement of `ISystProviderTool::GetEventResponse(art::Event const &)` we had earlier.